### PR TITLE
through2 should be in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
   },
   "author": "",
   "license": "ISC",
-  "devDependencies": {
-    "through2": "2.0.1"
-  },
   "dependencies": {
+    "through2": "2.0.1",
     "chalk": "1.1.1",
     "duplexer": "0.1.1",
     "figures": "1.4.0",


### PR DESCRIPTION
Otherwise it errors, since you try to use it in `index.js`.
